### PR TITLE
Fix replacing in contenteditable not generating any native input event

### DIFF
--- a/main/src/page-content/content-script.js
+++ b/main/src/page-content/content-script.js
@@ -124,11 +124,16 @@ function replaceCurrent(resultText) {
     const $mirror = $wrapper.find(SELECTORS.textareaContentMirror);
     $textarea.val($mirror.text());
   } else {
+    const contenteditable = $nodes.eq(0).closest('[contenteditable="true"]');
     // Contenteditable - we should use document.execCommand()
     $nodes.each((index, el) => {
       $(el).text(index == 0 ? resultText : "");
       Utils.flattenNode(el);
     });
+    // Trigger change event so that possible event listeners update appropriately
+    const nativeEvent = document.createEvent('Event');
+    nativeEvent.initEvent('input', true, true);
+    contenteditable.get(0).dispatchEvent(nativeEvent);
   }
 
   // Delete term mark-group from our list

--- a/main/src/page-content/content-script.js
+++ b/main/src/page-content/content-script.js
@@ -131,8 +131,7 @@ function replaceCurrent(resultText) {
       Utils.flattenNode(el);
     });
     // Trigger change event so that possible event listeners update appropriately
-    const nativeEvent = document.createEvent('Event');
-    nativeEvent.initEvent('input', true, true);
+    const nativeEvent = new Event('input', {bubbles: true, cancelable: true});
     contenteditable.get(0).dispatchEvent(nativeEvent);
   }
 


### PR DESCRIPTION
Currently the replacer doesn't generate a native "input" element for contenteditable-type elements.

This change fixes that and therefore allows e.g. angular2/4/5/6 @HostListener('input') to react to changes made by the replacer as if the user had manually entered the change